### PR TITLE
Sending custom attributes with traces

### DIFF
--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPlugin.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPlugin.kt
@@ -28,12 +28,19 @@ class OpenTelemetryBuildPlugin : Plugin<Project> {
                         null
                     }
 
+                    val customTags: Map<String, String>? = try {
+                        extension.customTags.orNull ?: mapOf()
+                    } catch (e: Exception) {
+                        null
+                    }
+
                     if (headers != null) {
                         val openTelemetry = OpenTelemetryInit(project.logger).init(
                             endpoint = endpoint,
                             headers = headers,
                             serviceName = serviceName,
                             exporterMode = extension.exporterMode.get(),
+                            customTags = customTags.orEmpty(),
                         )
 
                         val tracer = openTelemetry.getTracer(serviceName)

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPluginExtension.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPluginExtension.kt
@@ -9,6 +9,7 @@ abstract class OpenTelemetryBuildPluginExtension {
     abstract val serviceName: Property<String>
     abstract val exporterMode: Property<OpenTelemetryExporterMode>
     abstract val enabled: Property<Boolean>
+    abstract val customTags: MapProperty<String, String>
 
     init {
         exporterMode.convention(OpenTelemetryExporterMode.GRPC)

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryInit.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryInit.kt
@@ -1,5 +1,6 @@
 package com.atkinsondev.opentelemetry.build
 
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter
@@ -17,11 +18,17 @@ class OpenTelemetryInit(private val logger: Logger) {
         headers: Map<String, String>,
         serviceName: String,
         exporterMode: OpenTelemetryExporterMode,
+        customTags: Map<String, String>,
     ): OpenTelemetrySdk {
+        val customAttributesBuilder = Attributes.builder()
+        customTags.forEach { (key, value) -> customAttributesBuilder.put(key, value) }
+        val customAttributes = customAttributesBuilder.build()
+
         val customResourceAttributes = Resource.builder()
             .put(SERVICE_NAME, serviceName)
             .put(TELEMETRY_SDK_NAME, sdkName)
             .put(TELEMETRY_SDK_VERSION, sdkVersion)
+            .putAll(customAttributes)
             .build()
 
         val resource: Resource = Resource.getDefault()


### PR DESCRIPTION
Hey!

This is a rather small but useful update. It brings the possibility of adding custom tags that will be attached to traces. These tags can be set from build.settings file and they can describe an environment, for example. 

I tested it with Lightstep opentelemetry provider and also added a unit test.