### PR TITLE
Moving the error message string to the "error_message" attribute and making "error" be a boolean to render errors correctly in the Jaeger UI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: 11
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: 'gradle'
 
     - name: Build with Gradle

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -47,28 +47,30 @@ Each task has a child span created from the root build.
 The task spans are named with the task path, for example `:test`
 And each task span has the following attributes:
 
-| Span attribute name | Description |
-| ------------------- | ----------- |
-| `task.name`         | Name of the task, e.g. `test` |
-| `task.path`         | Full path to the task, including subproject names. E.g. `:app:test` |
-| `task.type`         | Full package and class name of the task, e.g. `org.gradle.api.tasks.testing.Test`
-| `task.outcome`      | Outcome of the task, e.g. `SUCCESS`, `UP-TO-DATE`, or `FROM-CACHE` |
-| `task.did_work`     | Whether the task did work (boolean) |
-| `error`             | If the task failed, the failure message |
-| `task.failed`       | Set to `true` if the task failed |
-| `task.failure`      | If the task failed, the failure message |
+| Span attribute name | Description                                                                       |
+|---------------------|-----------------------------------------------------------------------------------|
+| `task.name`         | Name of the task, e.g. `test`                                                     |
+| `task.path`         | Full path to the task, including subproject names. E.g. `:app:test`               |
+| `task.type`         | Full package and class name of the task, e.g. `org.gradle.api.tasks.testing.Test` |
+| `task.outcome`      | Outcome of the task, e.g. `SUCCESS`, `UP-TO-DATE`, or `FROM-CACHE`                |
+| `task.did_work`     | Whether the task did work (boolean)                                               |
+| `error`             | `true` if the task failed                                                         |
+| `error_message`     | If the task failed, the failure message                                           |
+| `task.failed`       | Set to `true` if the task failed                                                  |
+| `task.failure`      | If the task failed, the failure message                                           |
 
 And finally the plugin creates a child span off each `Test` type task for each test executed.
 The name of the per-test span is the full name of the test method.
 And the attributes on the per-test spans are:
 
-| Span attribute name       | Description |
-| ------------------------- | ----------- |
-| `test.result`             | Result of the test, e.g. `SUCCESS` or `FAILURE`
-| `error`                   | If the test failed, the failure message |
-| `test.failure.message`    | If the test failed, the failure message |
+| Span attribute name       | Description                                                |
+|---------------------------|------------------------------------------------------------|
+| `test.result`             | Result of the test, e.g. `SUCCESS` or `FAILURE`            |
+| `error`                   | `true` if the test failed                                  |
+| `error_message`           | If the test failed, the failure message                    |
+| `test.failure.message`    | If the test failed, the failure message                    |
 | `test.failure.stacktrace` | If the test failed, abbreviated stack trace of the failure |
-| `task.name`               | Name of the task, e.g. `test` |
+| `task.name`               | Name of the task, e.g. `test`                              |
 
 ### Remote parent trace
 
@@ -89,7 +91,7 @@ To start using the plugin, first add the plugin to the `plugins` block in your `
 
 ```
 plugins {
-    id 'com.atkinsondev.opentelemetry-build' version "1.9.1"
+    id 'com.atkinsondev.opentelemetry-build' version "1.10.0"
 }
 ```
 
@@ -156,6 +158,10 @@ The plugin is compatible with Gradle versions `6.1.1` and higher.
 
 ## Changelog
 
+* 1.10.0
+  * Moving the error message string to the `error_message` attribute and making `error` be a boolean to render errors correctly in the Jaeger UI
+  * Fixed problem where invalid parent span/trace ID error messages were logged when no parent or span IDs were set
+  * Updating to OpenTelemetry 1.36.0, Gradle 8.7, and Kotlin 1.9.22
 * 1.9.1
   * Fixing version in user-agent string
 * 1.9.0
@@ -169,8 +175,8 @@ The plugin is compatible with Gradle versions `6.1.1` and higher.
 * 1.6.1
   * Downgrading Kotlin 1.7.10 to match the Kotlin version bundled with Gradle 7.6 ([Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html#kotlin))
 * 1.6.0
-  * Adding support for custom telemetry attributes (thanks @kpriemchenko !) 
-  * Upgrading to OpenTelemetry 1.29.0 and Kotlin 1.9.0 
+  * Adding support for custom telemetry attributes (thanks @kpriemchenko !)
+  * Upgrading to OpenTelemetry 1.29.0 and Kotlin 1.9.0
 * 1.5.0
   * Upgrading to OpenTelemetry 1.22.0 and Kotlin 1.8.0
 * 1.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,17 @@ buildscript {
 }
 
 plugins {
-    id 'java-gradle-plugin'
-    id 'maven-publish'
-    id "org.jetbrains.kotlin.jvm" version "1.9.20" // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
+    id "java-gradle-plugin"
+    id "maven-publish"
+    id "org.jetbrains.kotlin.jvm" version "1.9.22" // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
     id "org.jlleitschuh.gradle.ktlint" version "12.1.0"
     id "dev.projektor.publish" version "8.7.0"
-    id 'com.gradle.plugin-publish' version "1.2.1"
+    id "com.gradle.plugin-publish" version "1.2.1"
     id "com.atkinsondev.opentelemetry-build" version "1.9.1"
 }
 
 group = "com.atkinsondev"
-version = "1.9.1"
+version = "1.10.0"
 
 gradlePlugin {
     website = 'https://github.com/craigatk/opentelemetry-gradle-plugin'
@@ -37,22 +37,21 @@ repositories {
 }
 
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:$otelVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:$otelVersion")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:$otelVersion")
-    implementation("io.opentelemetry:opentelemetry-exporter-zipkin:$otelVersion")
-    implementation("io.opentelemetry:opentelemetry-semconv:$otelSemConvVersion")
+    implementation "io.opentelemetry:opentelemetry-api:$otelVersion"
+    implementation "io.opentelemetry:opentelemetry-sdk:$otelVersion"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp:$otelVersion"
+    implementation "io.opentelemetry:opentelemetry-exporter-zipkin:$otelVersion"
+    implementation "io.opentelemetry:opentelemetry-semconv:$otelSemConvVersion"
 
     testImplementation gradleTestKit()
 
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation "org.junit.jupiter:junit-jupiter"
 
     testImplementation "org.wiremock:wiremock:3.5.2"
-
-    testImplementation("io.strikt:strikt-core:0.34.1")
-
-    testImplementation 'org.awaitility:awaitility-kotlin:4.2.1'
+    testImplementation "io.strikt:strikt-core:0.34.1"
+    testImplementation "org.awaitility:awaitility-kotlin:4.2.1"
+    testImplementation "io.mockk:mockk:1.13.10"
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPlugin.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPlugin.kt
@@ -141,16 +141,16 @@ class OpenTelemetryBuildPlugin : Plugin<Project> {
 
                         return remoteSpanContext
                     } else {
-                        logger.warn("Remote span context is not valid")
+                        logger.warn("Remote span context is not valid. Parent span ID: {} - parent trace ID: {}", parentSpanIdStr, parentTraceIdStr)
                     }
-                } else {
-                    if (parentSpanIdHex == null) {
-                        logger.warn("Received invalid parent span ID {}", parentSpanIdStr)
-                    }
+                }
 
-                    if (parentTraceIdHex == null) {
-                        logger.warn("Received invalid parent trace ID {}", parentTraceIdStr)
-                    }
+                if (parentSpanIdStr != null && parentSpanIdHex == null) {
+                    logger.info("Received invalid parent span ID {}", parentSpanIdStr)
+                }
+
+                if (parentTraceIdStr != null && parentTraceIdHex == null) {
+                    logger.info("Received invalid parent trace ID {}", parentTraceIdStr)
                 }
             }
 

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildSpanData.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildSpanData.kt
@@ -13,6 +13,7 @@ object OpenTelemetryBuildSpanData {
     const val TASK_DID_WORK_KEY = "task.did_work"
     const val TASK_OUTCOME_KEY = "task.outcome"
     const val ERROR_KEY = "error"
+    const val ERROR_MESSAGE_KEY = "error_message"
     const val TASK_FAILED_KEY = "task.failed"
     const val TASK_FAILURE_KEY = "task.failure"
 

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryInit.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryInit.kt
@@ -93,7 +93,7 @@ class OpenTelemetryInit(private val logger: Logger) {
 
     companion object {
         const val SDK_NAME = "gradle-opentelemetry-build-plugin"
-        const val SDK_VERSION = "1.9.1" // TODO: Find a way to pull this from the Gradle file
+        const val SDK_VERSION = "1.10.0" // TODO: Find a way to pull this from the Gradle file
         const val USER_AGENT_VALUE = "$SDK_NAME/$SDK_VERSION"
     }
 }

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTaskListener.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTaskListener.kt
@@ -1,6 +1,7 @@
 package com.atkinsondev.opentelemetry.build
 
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.ERROR_KEY
+import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.TASK_DID_WORK_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.TASK_FAILED_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.TASK_FAILURE_KEY
@@ -70,7 +71,8 @@ class OpenTelemetryTaskListener(
             span?.setAttribute(TASK_OUTCOME_KEY, taskState.outcome.toString())
 
             if (taskState.failure != null) {
-                span?.setAttribute(ERROR_KEY, taskState.failure?.message ?: "")
+                span?.setAttribute(ERROR_KEY, true)
+                span?.setAttribute(ERROR_MESSAGE_KEY, taskState.failure?.message ?: "")
                 span?.setAttribute(TASK_FAILED_KEY, true)
                 span?.setAttribute(TASK_FAILURE_KEY, taskState.failure?.message ?: "")
             }

--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTestListener.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTestListener.kt
@@ -1,6 +1,7 @@
 package com.atkinsondev.opentelemetry.build
 
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.ERROR_KEY
+import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.FAILURE_MESSAGE_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.FAILURE_STACKTRACE_KEY
 import com.atkinsondev.opentelemetry.build.OpenTelemetryBuildSpanData.TASK_NAME_KEY
@@ -80,7 +81,8 @@ class OpenTelemetryTestListener(
         val span = testSpanMap[testKey]
 
         if (testResultException != null) {
-            span?.setAttribute(ERROR_KEY, testResultException.message ?: "")
+            span?.setAttribute(ERROR_KEY, true)
+            span?.setAttribute(ERROR_MESSAGE_KEY, testResultException.message ?: "")
             span?.setAttribute(FAILURE_MESSAGE_KEY, testResultException.message ?: "")
             span?.setAttribute(FAILURE_STACKTRACE_KEY, truncatedStackTraceString(testResultException, stackTraceMaxDepth))
         }

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTaskListenerTest.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTaskListenerTest.kt
@@ -1,0 +1,84 @@
+package com.atkinsondev.opentelemetry.build
+
+import com.atkinsondev.opentelemetry.build.util.FakeSpanBuilder
+import com.atkinsondev.opentelemetry.build.util.FakeTracer
+import com.atkinsondev.opentelemetry.build.util.NoopLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.api.baggage.Baggage
+import io.opentelemetry.api.trace.*
+import org.gradle.api.internal.tasks.TaskExecutionOutcome
+import org.gradle.api.internal.tasks.TaskStateInternal
+import org.junit.jupiter.api.Test
+
+class OpenTelemetryTaskListenerTest {
+    @Test
+    fun `when test task fails should set error flag and error message attributes`() {
+        val rootSpan = mockk<Span>(relaxed = true)
+
+        val span = mockk<Span>()
+
+        every { span.setAttribute(any(String::class), any(Boolean::class)) } returns span
+        every { span.setAttribute(any(String::class), any(String::class)) } returns span
+        every { span.end() } returns Unit
+
+        val spanBuilder = FakeSpanBuilder(span)
+
+        val taskListener =
+            OpenTelemetryTaskListener(
+                tracer = FakeTracer(spanBuilder),
+                rootSpan = rootSpan,
+                baggage = Baggage.builder().build(),
+                logger = NoopLogger(),
+            )
+
+        val testTask = mockk<org.gradle.api.tasks.testing.Test>(relaxed = true)
+        every { testTask.path } returns ":proj:test"
+        every { testTask.name } returns "test"
+
+        val taskState = TaskStateInternal()
+        val exception = RuntimeException("failure message")
+        taskState.setOutcome(exception)
+
+        taskListener.beforeExecute(testTask)
+        taskListener.afterExecute(testTask, taskState)
+
+        verify { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_KEY, true) }
+        verify { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY, "failure message") }
+    }
+
+    @Test
+    fun `when test task pass should not set error flag and error message attributes`() {
+        val rootSpan = mockk<Span>(relaxed = true)
+
+        val span = mockk<Span>()
+
+        every { span.setAttribute(any(String::class), any(Boolean::class)) } returns span
+        every { span.setAttribute(any(String::class), any(String::class)) } returns span
+        every { span.end() } returns Unit
+
+        val spanBuilder = FakeSpanBuilder(span)
+
+        val taskListener =
+            OpenTelemetryTaskListener(
+                tracer = FakeTracer(spanBuilder),
+                rootSpan = rootSpan,
+                baggage = Baggage.builder().build(),
+                logger = NoopLogger(),
+            )
+
+        val testTask = mockk<org.gradle.api.tasks.testing.Test>(relaxed = true)
+        every { testTask.path } returns ":proj:test"
+        every { testTask.name } returns "test"
+
+        val taskState = TaskStateInternal()
+        taskState.outcome = TaskExecutionOutcome.EXECUTED
+
+        taskListener.beforeExecute(testTask)
+        taskListener.afterExecute(testTask, taskState)
+
+        verify(exactly = 0) { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_KEY, true) }
+        verify(exactly = 0) { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY, "failure message") }
+    }
+}

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTestListenerTest.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryTestListenerTest.kt
@@ -1,0 +1,113 @@
+package com.atkinsondev.opentelemetry.build
+
+import com.atkinsondev.opentelemetry.build.util.FakeSpanBuilder
+import com.atkinsondev.opentelemetry.build.util.FakeTracer
+import com.atkinsondev.opentelemetry.build.util.NoopLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.api.baggage.Baggage
+import io.opentelemetry.api.trace.Span
+import org.gradle.api.internal.tasks.testing.DefaultTestDescriptor
+import org.gradle.api.internal.tasks.testing.DefaultTestFailure
+import org.gradle.api.internal.tasks.testing.DefaultTestFailureDetails
+import org.gradle.api.internal.tasks.testing.results.DefaultTestResult
+import org.gradle.api.tasks.testing.TestResult
+import org.junit.jupiter.api.Test
+
+class OpenTelemetryTestListenerTest {
+    @Test
+    fun `when test fails should set error and error message attributes`() {
+        val testTaskSpan = mockk<Span>(relaxed = true)
+
+        val span = mockk<Span>()
+
+        every { span.setAttribute(any(String::class), any(Boolean::class)) } returns span
+        every { span.setAttribute(any(String::class), any(String::class)) } returns span
+        every { span.end() } returns Unit
+
+        val spanBuilder = FakeSpanBuilder(span)
+
+        val openTelemetryTestListener =
+            OpenTelemetryTestListener(
+                tracer = FakeTracer(spanBuilder),
+                testTaskSpan = testTaskSpan,
+                baggage = Baggage.builder().build(),
+                testTaskName = "test",
+                logger = NoopLogger(),
+            )
+
+        val testDescriptor = DefaultTestDescriptor(":test", "test.task.Klass", "failing test")
+
+        val testFailureDetails =
+            DefaultTestFailureDetails(
+                "test failure message",
+                "failure.Klass",
+                "stacktrace",
+                true,
+                false,
+                "true",
+                "false",
+                "true".toByteArray(),
+                "false".toByteArray(),
+            )
+
+        val testResult =
+            DefaultTestResult(
+                TestResult.ResultType.FAILURE,
+                109123,
+                109723,
+                1,
+                0,
+                1,
+                listOf(DefaultTestFailure(RuntimeException("test failure"), testFailureDetails, listOf())),
+            )
+
+        openTelemetryTestListener.beforeTest(testDescriptor)
+        openTelemetryTestListener.afterTest(testDescriptor, testResult)
+
+        verify { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_KEY, true) }
+        verify { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY, "test failure") }
+    }
+
+    @Test
+    fun `when test passes should not set error and error message attributes`() {
+        val testTaskSpan = mockk<Span>(relaxed = true)
+
+        val span = mockk<Span>()
+
+        every { span.setAttribute(any(String::class), any(Boolean::class)) } returns span
+        every { span.setAttribute(any(String::class), any(String::class)) } returns span
+        every { span.end() } returns Unit
+
+        val spanBuilder = FakeSpanBuilder(span)
+
+        val openTelemetryTestListener =
+            OpenTelemetryTestListener(
+                tracer = FakeTracer(spanBuilder),
+                testTaskSpan = testTaskSpan,
+                baggage = Baggage.builder().build(),
+                testTaskName = "test",
+                logger = NoopLogger(),
+            )
+
+        val testDescriptor = DefaultTestDescriptor(":test", "test.task.Klass", "passing test")
+
+        val testResult =
+            DefaultTestResult(
+                TestResult.ResultType.SUCCESS,
+                109123,
+                109723,
+                1,
+                1,
+                0,
+                listOf(),
+            )
+
+        openTelemetryTestListener.beforeTest(testDescriptor)
+        openTelemetryTestListener.afterTest(testDescriptor, testResult)
+
+        verify(exactly = 0) { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_KEY, any(Boolean::class)) }
+        verify(exactly = 0) { span.setAttribute(OpenTelemetryBuildSpanData.ERROR_MESSAGE_KEY, any(String::class)) }
+    }
+}

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/FakeSpanBuilder.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/FakeSpanBuilder.kt
@@ -1,0 +1,81 @@
+package com.atkinsondev.opentelemetry.build.util
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import java.util.concurrent.TimeUnit
+
+class FakeSpanBuilder(private val span: Span) : SpanBuilder {
+    override fun setParent(context: Context): SpanBuilder {
+        return this
+    }
+
+    override fun setNoParent(): SpanBuilder {
+        return this
+    }
+
+    override fun addLink(spanContext: SpanContext): SpanBuilder {
+        return this
+    }
+
+    override fun addLink(
+        spanContext: SpanContext,
+        attributes: Attributes,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun setAttribute(
+        key: String,
+        value: String,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun setAttribute(
+        key: String,
+        value: Long,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun setAttribute(
+        key: String,
+        value: Double,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun setAttribute(
+        key: String,
+        value: Boolean,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun <T : Any?> setAttribute(
+        key: AttributeKey<T>,
+        value: T,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun setSpanKind(spanKind: SpanKind): SpanBuilder {
+        return this
+    }
+
+    override fun setStartTimestamp(
+        startTimestamp: Long,
+        unit: TimeUnit,
+    ): SpanBuilder {
+        return this
+    }
+
+    override fun startSpan(): Span {
+        return span
+    }
+}

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/FakeTracer.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/FakeTracer.kt
@@ -1,0 +1,10 @@
+package com.atkinsondev.opentelemetry.build.util
+
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.Tracer
+
+class FakeTracer(private val spanBuilder: SpanBuilder) : Tracer {
+    override fun spanBuilder(spanName: String): SpanBuilder {
+        return spanBuilder
+    }
+}

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/NoopLogger.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/util/NoopLogger.kt
@@ -1,0 +1,485 @@
+package com.atkinsondev.opentelemetry.build.util
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
+import org.slf4j.Marker
+
+class NoopLogger : Logger {
+    override fun getName(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun isTraceEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isTraceEnabled(p0: Marker?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: String?,
+        p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: String?,
+        p1: Any?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: Marker?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+        p3: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: Marker?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun trace(
+        p0: Marker?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isDebugEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isDebugEnabled(p0: Marker?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: String?,
+        p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: String?,
+        p1: Any?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: Marker?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+        p3: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: Marker?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun debug(
+        p0: Marker?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isInfoEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isInfoEnabled(p0: Marker?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: String?,
+        p1: Any?,
+    ) {
+    }
+
+    override fun info(
+        p0: String?,
+        p1: Any?,
+        p2: Any?,
+    ) {
+    }
+
+    override fun info(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: Marker?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+        p3: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: Marker?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun info(
+        p0: Marker?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isWarnEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isWarnEnabled(p0: Marker?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: String?,
+        p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: String?,
+        p1: Any?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: Marker?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+        p3: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: Marker?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun warn(
+        p0: Marker?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isErrorEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isErrorEnabled(p0: Marker?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: String?,
+        p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: String?,
+        p1: Any?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: Marker?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: Marker?,
+        p1: String?,
+        p2: Any?,
+        p3: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: Marker?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun error(
+        p0: Marker?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isLifecycleEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun lifecycle(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun lifecycle(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun lifecycle(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isQuietEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun quiet(p0: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun quiet(
+        p0: String?,
+        vararg p1: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun quiet(
+        p0: String?,
+        p1: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isEnabled(p0: LogLevel?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun log(
+        p0: LogLevel?,
+        p1: String?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun log(
+        p0: LogLevel?,
+        p1: String?,
+        vararg p2: Any?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun log(
+        p0: LogLevel?,
+        p1: String?,
+        p2: Throwable?,
+    ) {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
Ref #126