### PR TITLE
enable recording of child spans when remote parent exists. fixes #135

### DIFF
--- a/src/main/kotlin/com/atkinsondev/opentelemetry/build/RemoteParentTracer.kt
+++ b/src/main/kotlin/com/atkinsondev/opentelemetry/build/RemoteParentTracer.kt
@@ -14,7 +14,7 @@ object RemoteParentTracer {
         SpanContext.createFromRemoteParent(
             parentTraceIdHex,
             parentSpanIdHex,
-            TraceFlags.getDefault(),
+            TraceFlags.getSampled(),
             TraceState.builder().build(),
         )
 }

--- a/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPluginRemoteParentTraceTest.kt
+++ b/src/test/kotlin/com/atkinsondev/opentelemetry/build/OpenTelemetryBuildPluginRemoteParentTraceTest.kt
@@ -1,8 +1,9 @@
 package com.atkinsondev.opentelemetry.build
 
-import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import org.awaitility.Awaitility.await
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.io.TempDir
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
 import java.io.File
 import java.nio.file.Path
 
@@ -37,7 +39,7 @@ class OpenTelemetryBuildPluginRemoteParentTraceTest {
         createSrcDirectoryAndClassFile(projectRootDirPath)
         createTestDirectoryAndClassFile(projectRootDirPath)
 
-        WireMock.stubFor(WireMock.post("/otel").willReturn(WireMock.ok()))
+        stubFor(post("/otel").willReturn(ok()))
 
         val buildResult =
             GradleRunner.create()
@@ -57,6 +59,12 @@ class OpenTelemetryBuildPluginRemoteParentTraceTest {
             buildResult.output,
         ).contains("Using parent span ID f1a2153e247b0d94 and parent trace ID a263fdf001993a32980b9ec5740b7d6d")
         expectThat(buildResult.output).contains("OpenTelemetry build trace ID a263fdf001993a32980b9ec5740b7d6d")
+
+        await().untilAsserted {
+            val otelRequests = findAll(postRequestedFor(urlEqualTo("/otel")))
+
+            expectThat(otelRequests).isNotEmpty()
+        }
     }
 
     @Test
@@ -81,7 +89,7 @@ class OpenTelemetryBuildPluginRemoteParentTraceTest {
         createSrcDirectoryAndClassFile(projectRootDirPath)
         createTestDirectoryAndClassFile(projectRootDirPath)
 
-        WireMock.stubFor(WireMock.post("/otel").willReturn(WireMock.ok()))
+        stubFor(post("/otel").willReturn(ok()))
 
         val buildResult =
             GradleRunner.create()


### PR DESCRIPTION
Hi, this change enables the recording of traces when a parent trace is available.

fixes #135

i found the answer here:
https://stackoverflow.com/questions/70700163/opentelemetry-context-propagation-test

thanks!